### PR TITLE
flush the write-buffer before gofmt/goimports

### DIFF
--- a/main.go
+++ b/main.go
@@ -294,6 +294,10 @@ import (
 	if err != nil {
 		log.Fatalf("failed to execute template: %v", err)
 	}
+	err = f.Sync()
+	if err != nil {
+		log.Fatalf("failed to sync: %v", err)
+	}
 
 	runGoImports(outputFilename)
 	runGoFmt(outputFilename)


### PR DESCRIPTION
ファイルに書き込みをした場合、closeでエラーになる場合があります。今の実装だとcloseのエラーをみていないのだけど、それよりも事前にfsyncする方法が良いとされているので、そのように変更しました。

ref https://togetter.com/li/583503